### PR TITLE
Remove Tip that references Sound documentation

### DIFF
--- a/microsoft.ui.xaml.controls/animatedvisualplayer.md
+++ b/microsoft.ui.xaml.controls/animatedvisualplayer.md
@@ -24,9 +24,7 @@ The AnimatedVisualPlayer hosts and controls playback of an animated [Visual](htt
 
 ## -examples
 
-> [!TIP]
-> For more info, design guidance, and code examples, see [Sound](/windows/uwp/design/style/sound).
->
+
 > If you have the **XAML Controls Gallery** app installed, click here to [open the app and see the AnimatedVisualPlayer in action](xamlcontrolsgallery:/item/AnimatedVisualPlayer).
 > + [Get the XAML Controls Gallery app (Microsoft Store)](https://www.microsoft.com/store/productId/9MSVH128X2ZT)
 > + [Get the source code (GitHub)](https://github.com/Microsoft/Xaml-Controls-Gallery)

--- a/microsoft.ui.xaml.controls/animatedvisualplayer.md
+++ b/microsoft.ui.xaml.controls/animatedvisualplayer.md
@@ -24,7 +24,6 @@ The AnimatedVisualPlayer hosts and controls playback of an animated [Visual](htt
 
 ## -examples
 
-
-> If you have the **XAML Controls Gallery** app installed, click here to [open the app and see the AnimatedVisualPlayer in action](xamlcontrolsgallery:/item/AnimatedVisualPlayer).
-> + [Get the XAML Controls Gallery app (Microsoft Store)](https://www.microsoft.com/store/productId/9MSVH128X2ZT)
-> + [Get the source code (GitHub)](https://github.com/Microsoft/Xaml-Controls-Gallery)
+If you have the **XAML Controls Gallery** app installed, click here to [open the app and see the AnimatedVisualPlayer in action](xamlcontrolsgallery:/item/AnimatedVisualPlayer).
+ + [Get the XAML Controls Gallery app (Microsoft Store)](https://www.microsoft.com/store/productId/9MSVH128X2ZT)
+ + [Get the source code (GitHub)](https://github.com/Microsoft/Xaml-Controls-Gallery)


### PR DESCRIPTION
there appears to be an incorrect Tip that got for whatever reason. This control has nothing to do with Sound.