### PR TITLE
Fix typo on NavigationViewItem MenuItemsSource page

### DIFF
--- a/microsoft.ui.xaml.controls/navigationviewitem_menuitemssource.md
+++ b/microsoft.ui.xaml.controls/navigationviewitem_menuitemssource.md
@@ -21,7 +21,7 @@ The object source that holds the children of the NavigationViewItem.
 
 
 ## -examples
-This example adds hierarchy buy defining the item template to be a NavigationViewMenuItem, with its Content set to be the label of the menu item, and its MenuItemsSource property bound to the next level of the hierarchy.
+This example adds hierarchy by defining the item template to be a NavigationViewMenuItem, with its Content set to be the label of the menu item, and its MenuItemsSource property bound to the next level of the hierarchy.
 
 ```xaml
 <DataTemplate x:Key="NavigationViewMenuItem" x:DataType="local:Category">


### PR DESCRIPTION
The description of the sample stated:

"This example adds hierarchy buy defining [...]" 

Instead it should be "[...] by defining [...]" I think.