### PR TITLE
TeachingTip: Improve [examples] section

### DIFF
--- a/microsoft.ui.xaml.controls/teachingtip.md
+++ b/microsoft.ui.xaml.controls/teachingtip.md
@@ -23,10 +23,9 @@ Teaching tips are often used for informing, reminding, and teaching users about 
 
 ## -examples
 
-See the **XAML Controls Gallery** sample app for examples of WinUI features and controls.
-
-If you have the **XAML Controls Gallery** app installed, see the [TeachingTip](xamlcontrolsgallery:/item/TeachingTip) in action.
-
-If you don't have the XAML Controls Gallery app installed, get the WinUI 2.x version from the [Microsoft Store](https://www.microsoft.com/p/xaml-controls-gallery/9msvh128x2zt).
-
-You can also view, clone, and build the XAML Controls Gallery source code from [GitHub](https://github.com/Microsoft/Xaml-Controls-Gallery) (switch to the [WinUI 3 Preview branch](https://github.com/microsoft/Xaml-Controls-Gallery/tree/winui3preview) for WinUI 3 Preview controls and features).
+> [!TIP]
+> For more info, design guidance, and code examples, see [Teaching tip](/windows/uwp/design/controls-and-patterns/dialogs-and-flyouts/teaching-tip).
+>
+> If you have the **XAML Controls Gallery** app installed, click [here to open the app and see the TeachingTip in action](xamlcontrolsgallery:/item/TeachingTip).
+> + [Get the XAML Controls Gallery app (Microsoft Store)](https://www.microsoft.com/store/productId/9MSVH128X2ZT)
+> + [Get the source code (GitHub)](https://github.com/Microsoft/Xaml-Controls-Gallery)


### PR DESCRIPTION
This PR aims to improve the [examples] section of the [TeachingTip API documentation](https://docs.microsoft.com/en-us/uwp/api/microsoft.ui.xaml.controls.teachingtip?view=winui-2.4). It follows the design of the other documentations like the [NavigationView API documentation](https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.navigationview?view=winrt-19041#examples):
![image](https://user-images.githubusercontent.com/1398851/96621638-29b08600-1309-11eb-99e5-be876f3eea3e.png)

What I prefer about that examples section vs the existing one used for the TeachingTip is that we here provide a link to the [TeachingTip overview documentation](https://docs.microsoft.com/en-us/windows/uwp/design/controls-and-patterns/dialogs-and-flyouts/teaching-tip) right at the top of the API documentation instead of just at the bottom ("See also" section).

I did a slight change compared to the Navigation view examples section: The hyperlink to open the XAMl Control Gallery now reads "here to open the app and see the NavigationView in action." instead of "open the app and see the NavigationView in action." I felt it more natural to also include the "here to" words.

If this PR is a welcome change I plan to create similar PRs for other WinUI Control API documentations like [NumberBox](https://docs.microsoft.com/en-us/uwp/api/microsoft.ui.xaml.controls.numberbox?view=winui-2.4) or [TabView](https://docs.microsoft.com/en-us/uwp/api/microsoft.ui.xaml.controls.tabview?view=winui-2.4).