### PR TITLE
Update TextBox.TextAlignment to reference HorizontalTextAlignment

### DIFF
--- a/microsoft.ui.xaml.controls/textbox_textalignment.md
+++ b/microsoft.ui.xaml.controls/textbox_textalignment.md
@@ -17,10 +17,10 @@ Gets or sets how the text should be horizontally aligned in the text box.
 <TextBox TextAlignment="textAlignmentMemberName"/>
 ```
 
-
 ## -xaml-values
-<dl><dt>textAlignmentMemberName</dt><dd>textAlignmentMemberNameA named constant of the TextAlignment enumeration, for example Center.</dd>
+<dl><dt>textAlignmentMemberName</dt><dd>A named constant of the TextAlignment enumeration, for example Center.</dd>
 </dl>
+
 ## -property-value
 One of the [TextAlignment](../microsoft.ui.xaml/textalignment.md) enumeration values. The default is **Left**.
 

--- a/microsoft.ui.xaml.controls/textbox_textalignment.md
+++ b/microsoft.ui.xaml.controls/textbox_textalignment.md
@@ -25,6 +25,7 @@ Gets or sets how the text should be horizontally aligned in the text box.
 One of the [TextAlignment](../microsoft.ui.xaml/textalignment.md) enumeration values. The default is **Left**.
 
 ## -remarks
+This property provides the same functionality as the HorizontalTextAlignment property. If both properties are set to conflicting values, the last one set is used.
 
 ## -examples
 


### PR DESCRIPTION
The TextAlignment and HorizontalTextAlignment properties are synonyms for each other. The latter page already calls this out, this is adding the same remark to the former.