### PR TITLE
Modifies titlebar api to remove margin in code samples and recommendations

### DIFF
--- a/microsoft.ui.xaml/window_extendscontentintotitlebar.md
+++ b/microsoft.ui.xaml/window_extendscontentintotitlebar.md
@@ -23,7 +23,7 @@ Use this property in conjunction with the [SetTitleBar](window_settitlebar_14947
 
 To specify a custom title bar, you must set `ExtendsContentIntoTitleBar` to `true` to hide the default system title bar. If `ExtendsContentIntoTitleBar` is `false`, a call to `SetTitleBar` does not have any effect. Your custom title bar element is shown in the body of your app window as an ordinary UI element and does not get the title bar behaviors.
 
-If you set `ExtendsContentIntoTitleBar` to `true` but do not call `SetTitleBar`, the system title bar is restricted to the caption buttons and a small area next to the caption buttons that is reserved for title bar behaviors. However, your custom title bar element does not get title bar behaviors, such as drag and the system menu, until [SetTitleBar](window_settitlebar_1494775390.md) is called with a valid [UIElement](uielement.md).
+If you set `ExtendsContentIntoTitleBar` to `true` but do not call `SetTitleBar`, the system title bar is restricted to the caption buttons and a small area next to the caption buttons that is reserved for title bar behaviors. It is called Fallback Titlebar. However, your custom title bar element does not get title bar behaviors, such as drag and the system menu, until [SetTitleBar](window_settitlebar_1494775390.md) is called with a valid [UIElement](uielement.md).
 
 ## -see-also
 

--- a/microsoft.ui.xaml/window_settitlebar_1494775390.md
+++ b/microsoft.ui.xaml/window_settitlebar_1494775390.md
@@ -52,7 +52,7 @@ For example:
 
 ## Colors
 
-When you use a custom title bar, you can modify the colors of the caption buttons to match your app. To do so, override the following resources (shown here with their default values):
+When you use a custom title bar, you can modify the colors of the caption buttons to match your app.  To do so, override the following resources (shown here with their default values):
 
 ```xaml
 <StaticResource x:Key="WindowCaptionBackground" ResourceKey="SystemControlBackgroundBaseLowBrush" />

--- a/microsoft.ui.xaml/window_settitlebar_1494775390.md
+++ b/microsoft.ui.xaml/window_settitlebar_1494775390.md
@@ -29,15 +29,13 @@ The rectangular area occupied by the specified element acts as the title bar for
 
 To specify a custom title bar, you must set [ExtendsContentIntoTitleBar](window_extendscontentintotitlebar.md) to `true` to hide the default system title bar. If `ExtendsContentIntoTitleBar` is `false`, the call to `SetTitleBar` does not have any effect. Your custom title bar element is shown in the body of your app window as an ordinary UI element and does not get the title bar behaviors.
 
-If you set [ExtendsContentIntoTitleBar](window_extendscontentintotitlebar.md) to `true` but do not call `SetTitleBar`, the system title bar is restricted to the caption buttons and a small area next to the caption buttons that is reserved for title bar behaviors. However, your custom title bar element does not get title bar behaviors, such as drag and the system menu, until [SetTitleBar](window_settitlebar_1494775390.md) is called with a valid [UIElement](uielement.md).
+If you set [ExtendsContentIntoTitleBar](window_extendscontentintotitlebar.md) to `true` but do not call `SetTitleBar`, the system title bar is restricted to the caption buttons and a small area next to the caption buttons that is reserved for title bar behaviors. It is called Fallback Titlebar. However, your custom title bar element does not get title bar behaviors, such as drag and the system menu, until [SetTitleBar](window_settitlebar_1494775390.md) is called with a valid [UIElement](uielement.md).
 
 ## Title bar element
 
 Only a single element can be specified as the title bar. If multiple elements are required, they can be specified as child elements of a single container (such as a [Grid](../microsoft.ui.xaml.controls/grid.md) or [StackPanel](../microsoft.ui.xaml.controls/stackpanel.md)). If multiple elements are specified instead of a container, the last element specified is used.
 
-The title bar element is presented over the caption buttons, so you should set the side margins of your UIElement to leave space for the caption buttons. (If the title bar element has a transparent background, the caption buttons will show through but will not receive any input.) For example, if all caption buttons (minimize, maximize/restore, and close) are shown on the right side of the window, your title bar element should have a right margin value of 120 to ensure enough space for the buttons.
-
-The custom title bar works best when it is the top-most child of the parent container of your app. Deep nesting the [UIElement](uielement.md) within the XAML tree might cause unpredictable layout behaviors.
+The custom title bar works best when it is the top-most child of the parent container of your app. Deep nesting the [UIElement](uielement.md) within the XAML tree might cause unpredictable layout behaviors. Adding right margin to the titlebar [UIElement](uielement.md) also affects its functionality and is not recommended. 
 
 For example:
 
@@ -45,7 +43,7 @@ For example:
 <!-- NOT RECOMMENDED -->
 <Grid x:Name="RootGrid">
     <StackPanel>
-        <StackPanel x:Name="CustomTitleBar">
+        <StackPanel x:Name="CustomTitleBar" Margin="0,0,120,0">
         <... more XAML ...>
     </StackPanel>
     <... more XAML ...>
@@ -93,7 +91,7 @@ This example shows how to extend the window's content area and replace the syste
             <RowDefinition/>
         </Grid.RowDefinitions>
 
-        <Grid x:Name="AppTitleBar" Margin="0,0,120,0">
+        <Grid x:Name="AppTitleBar">
             <Image Source="Images/WindowIcon.png"
                    HorizontalAlignment="Left" 
                    Width="16" Height="16" 


### PR DESCRIPTION
With new release of winui, right margins are not recommended to be used with custom titlebar. This PR modifies the docs to reflect that. It also introduces Fallback titlebar as a term for the null titlebar case.

The commits can be squished to a single one.