### PR TITLE
Fix INotifyCollectionChanged link and clarify it can be used from C++ in more places

### DIFF
--- a/microsoft.ui.xaml.controls/itemsrepeater_itemssource.md
+++ b/microsoft.ui.xaml.controls/itemsrepeater_itemssource.md
@@ -46,7 +46,7 @@ This list shows available interfaces and when to consider using each one.
     **Warning**:
     Changes to the list/vector without implementing [INotifyCollectionChanged](/dotnet/api/system.collections.specialized.inotifycollectionchanged?view=dotnet-uwp-10.0&preserve-view=true) won't be reflected in the UI.
 
-- [INotifyCollectionChanged](../microsoft.ui.xaml.interop/inotifycollectionchanged.md)
+- [INotifyCollectionChanged](/uwp/api/windows.ui.xaml.interop.inotifycollectionchanged)
 
   - Recommended to support change notification.
 

--- a/microsoft.ui.xaml.controls/treeview_itemssource.md
+++ b/microsoft.ui.xaml.controls/treeview_itemssource.md
@@ -43,7 +43,7 @@ The ItemsControl can respond to changes if the ItemsSource property value also i
 
 | C++ | .NET |
 | -- | -- |
-| [IObservableVector](/uwp/api/windows.foundation.collections.iobservablevector_t_)&lt;[IInspectable](/windows/win32/api/inspectable/nn-inspectable-iinspectable)&gt; | [INotifyCollectionChanged](/dotnet/api/system.collections.specialized.inotifycollectionchanged?view=dotnet-uwp-10.0&preserve-view=true) |
+| [IObservableVector](/uwp/api/windows.foundation.collections.iobservablevector_t_)&lt;[IInspectable](/windows/win32/api/inspectable/nn-inspectable-iinspectable)&gt; or [INotifyCollectionChanged](/uwp/api/windows.ui.xaml.interop.inotifycollectionchanged) | [INotifyCollectionChanged](/dotnet/api/system.collections.specialized.inotifycollectionchanged?view=dotnet-uwp-10.0&preserve-view=true) |
 
 ## -see-also
 

--- a/microsoft.ui.xaml.controls/treeviewitem_itemssource.md
+++ b/microsoft.ui.xaml.controls/treeviewitem_itemssource.md
@@ -43,7 +43,7 @@ The ItemsControl can respond to changes if the ItemsSource property value also i
 
 | C++ | .NET |
 | -- | -- |
-| [IObservableVector](/uwp/api/windows.foundation.collections.iobservablevector_t_)&lt;[IInspectable](/windows/win32/api/inspectable/nn-inspectable-iinspectable)&gt; | [INotifyCollectionChanged](/dotnet/api/system.collections.specialized.inotifycollectionchanged?view=dotnet-uwp-10.0&preserve-view=true) |
+| [IObservableVector](/uwp/api/windows.foundation.collections.iobservablevector_t_)&lt;[IInspectable](/windows/win32/api/inspectable/nn-inspectable-iinspectable)&gt; or [INotifyCollectionChanged](/uwp/api/windows.ui.xaml.interop.inotifycollectionchanged) | [INotifyCollectionChanged](/dotnet/api/system.collections.specialized.inotifycollectionchanged?view=dotnet-uwp-10.0&preserve-view=true) |
 
 ## -see-also
 


### PR DESCRIPTION
Redo of #123. Original PR comment follows.

Follow up to https://github.com/MicrosoftDocs/winui-api/pull/122. Fixes the broken link. When I first made the previous PR, I assumed it was WASDK docs, in which case the link would be correct. But it's not.

Also fixes more place where INCC is mentioned as .NET only.