### PR TITLE
Fix typo on Treeview.HasUnrealizedChildren property

### DIFF
--- a/microsoft.ui.xaml.controls/treeviewnode_hasunrealizedchildren.md
+++ b/microsoft.ui.xaml.controls/treeviewnode_hasunrealizedchildren.md
@@ -18,7 +18,7 @@ Gets or sets a value that indicates whether the current node has child items tha
 
 ## -property-value
 
-**true** of the current node has child items that haven't been shown; otherwise, **false**.
+**true** if the current node has child items that haven't been shown; otherwise, **false**.
 
 
 ## -remarks


### PR DESCRIPTION
Fixes typo for the WinUI 3 of the Treeview.HasUnrealizedChildren property.